### PR TITLE
Implement simple uploading service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# codextest69
-testing the capabilities of agentic ai workflows.
+# codextest69 Uploader
+
+A simple Flask-based file and text sharing service.
+
+## Features
+- Guest uploads up to 10 MB
+- Registered users uploads up to 40 MB
+- Pastebin-like text sharing with editing
+- Admin dashboard to monitor users and files
+- Rate limited endpoints
+
+## Development
+Install dependencies and run:
+```bash
+pip install -r requirements.txt
+python -m app.main
+```
+
+## Testing
+Run the unit tests with:
+```bash
+pytest
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,18 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'dev'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+app.config['UPLOAD_FOLDER'] = 'app/static/uploads'
+app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024
+
+db = SQLAlchemy(app)
+login_manager = LoginManager(app)
+limiter = Limiter(key_func=get_remote_address)
+limiter.init_app(app)
+
+from . import routes, models, paste, utils

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,6 @@
+from . import app, db
+
+if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
+    app.run(debug=True, host='0.0.0.0')

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,31 @@
+from datetime import datetime, timedelta
+from . import db, login_manager
+from flask_login import UserMixin
+
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password = db.Column(db.String(120), nullable=False)
+    is_admin = db.Column(db.Boolean, default=False)
+    files = db.relationship('File', backref='owner', lazy=True)
+    pastes = db.relationship('Paste', backref='owner', lazy=True)
+
+class File(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    filename = db.Column(db.String(120), nullable=False)
+    stored_name = db.Column(db.String(120), nullable=False)
+    upload_time = db.Column(db.DateTime, default=datetime.utcnow)
+    expire_at = db.Column(db.DateTime, nullable=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    session_id = db.Column(db.String(120), nullable=True)
+
+class Paste(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    content = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    session_id = db.Column(db.String(120), nullable=True)
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))

--- a/app/paste.py
+++ b/app/paste.py
@@ -1,0 +1,48 @@
+from flask import render_template, request, redirect, url_for, flash, session
+from flask_login import current_user, login_required
+
+from . import app, db, limiter
+from .models import Paste
+
+@app.route('/paste', methods=['GET', 'POST'])
+@limiter.limit('30/minute')
+def create_paste():
+    if request.method == 'POST':
+        content = request.form['content']
+        p = Paste(content=content)
+        if current_user.is_authenticated:
+            p.owner = current_user
+        else:
+            p.session_id = session.get('sid')
+        db.session.add(p)
+        db.session.commit()
+        return redirect(url_for('view_paste', paste_id=p.id))
+    return render_template('paste.html')
+
+@app.route('/paste/<int:paste_id>', methods=['GET', 'POST'])
+def view_paste(paste_id):
+    p = Paste.query.get_or_404(paste_id)
+    if request.method == 'POST':
+        if can_edit(p):
+            p.content = request.form['content']
+            db.session.commit()
+            flash('Updated')
+        else:
+            flash('Access denied')
+    return render_template('view_paste.html', paste=p)
+
+@app.route('/paste/<int:paste_id>/delete')
+@login_required
+def delete_paste(paste_id):
+    p = Paste.query.get_or_404(paste_id)
+    if not can_edit(p):
+        flash('Access denied')
+    else:
+        db.session.delete(p)
+        db.session.commit()
+        flash('Deleted')
+    return redirect(url_for('index'))
+
+
+def can_edit(paste):
+    return current_user.is_authenticated and (paste.owner == current_user or current_user.is_admin)

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,152 @@
+import os
+from datetime import datetime
+from flask import render_template, redirect, url_for, request, flash, session, send_from_directory
+from flask_login import login_user, logout_user, current_user, login_required
+from werkzeug.security import generate_password_hash, check_password_hash
+from werkzeug.utils import secure_filename
+
+from . import app, db, limiter
+from .models import User, File
+
+ALLOWED_EXTENSIONS = set(['txt', 'png', 'jpg', 'jpeg', 'gif', 'pdf'])
+
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+@app.route('/')
+def index():
+    files = get_user_files()
+    return render_template('index.html', files=files)
+
+@app.route('/register', methods=['GET', 'POST'])
+@limiter.limit('5/minute')
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = generate_password_hash(request.form['password'])
+        if User.query.filter_by(username=username).first():
+            flash('Username exists')
+        else:
+            user = User(username=username, password=password)
+            db.session.add(user)
+            db.session.commit()
+            flash('Registered, please login')
+            return redirect(url_for('login'))
+    return render_template('register.html')
+
+@app.route('/login', methods=['GET', 'POST'])
+@limiter.limit('10/minute')
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and check_password_hash(user.password, password):
+            login_user(user)
+            return redirect(url_for('index'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('index'))
+
+@app.route('/upload', methods=['POST'])
+@limiter.limit('20/minute')
+def upload():
+    file = request.files.get('file')
+    if not file or file.filename == '':
+        flash('No file selected')
+        return redirect(url_for('index'))
+    if not allowed_file(file.filename):
+        flash('File type not allowed')
+        return redirect(url_for('index'))
+    if current_user.is_authenticated:
+        max_size = 40 * 1024 * 1024
+    else:
+        max_size = 10 * 1024 * 1024
+    file.seek(0, os.SEEK_END)
+    size = file.tell()
+    file.seek(0)
+    if size > max_size:
+        flash('File too large')
+        return redirect(url_for('index'))
+    filename = secure_filename(file.filename)
+    stored = f"{datetime.utcnow().timestamp()}_{filename}"
+    path = os.path.join(app.config['UPLOAD_FOLDER'], stored)
+    file.save(path)
+    f = File(filename=filename, stored_name=stored)
+    if current_user.is_authenticated:
+        f.owner = current_user
+    else:
+        f.session_id = session.get('sid')
+    db.session.add(f)
+    db.session.commit()
+    flash('Uploaded')
+    return redirect(url_for('index'))
+
+@app.route('/files/<name>')
+def uploaded_file(name):
+    return send_from_directory(app.config['UPLOAD_FOLDER'], name)
+
+@app.route('/file/<int:file_id>/delete')
+@login_required
+def delete_file(file_id):
+    f = File.query.get_or_404(file_id)
+    if not can_access(f):
+        flash('Access denied')
+        return redirect(url_for('index'))
+    db.session.delete(f)
+    db.session.commit()
+    flash('Deleted')
+    return redirect(url_for('index'))
+
+@app.route('/file/<int:file_id>/rename', methods=['POST'])
+@login_required
+def rename_file(file_id):
+    f = File.query.get_or_404(file_id)
+    if not can_access(f):
+        flash('Access denied')
+        return redirect(url_for('index'))
+    newname = request.form.get('name')
+    if newname:
+        f.filename = secure_filename(newname)
+        db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/file/<int:file_id>/expire', methods=['POST'])
+@login_required
+def set_expiration(file_id):
+    f = File.query.get_or_404(file_id)
+    if not can_access(f):
+        flash('Access denied')
+        return redirect(url_for('index'))
+    date = request.form.get('expire')
+    if date:
+        f.expire_at = datetime.fromisoformat(date)
+        db.session.commit()
+    return redirect(url_for('index'))
+
+@app.route('/admin')
+@login_required
+def admin():
+    if not current_user.is_admin:
+        flash('Admin only')
+        return redirect(url_for('index'))
+    users = User.query.all()
+    files = File.query.all()
+    return render_template('admin.html', users=users, files=files)
+
+def get_user_files():
+    if current_user.is_authenticated:
+        files = File.query.filter_by(user_id=current_user.id).all()
+    else:
+        sid = session.get('sid')
+        files = File.query.filter_by(session_id=sid).all()
+    return files
+
+def can_access(file):
+    return current_user.is_authenticated and (file.owner == current_user or current_user.is_admin)

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,0 +1,19 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title">Admin Dashboard</h2>
+<p>Users: {{ users|length }}, Files: {{ files|length }}</p>
+<table class="table is-fullwidth">
+<tr><th>User</th><th>Admin</th></tr>
+{% for u in users %}
+<tr>
+<td>{{ u.username }}</td><td>{{ 'Yes' if u.is_admin else 'No' }}</td>
+</tr>
+{% endfor %}
+</table>
+<table class="table is-fullwidth">
+<tr><th>File</th><th>User</th></tr>
+{% for f in files %}
+<tr><td>{{ f.filename }}</td><td>{{ f.owner.username if f.owner else 'Guest' }}</td></tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,38 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1 class="title">Welcome{% if current_user.is_authenticated %}, {{ current_user.username }}{% endif %}</h1>
+
+{% if not current_user.is_authenticated %}
+<p><a href="{{ url_for('login') }}">Login</a> or <a href="{{ url_for('register') }}">Register</a></p>
+{% else %}
+<p><a href="{{ url_for('logout') }}">Logout</a>{% if current_user.is_admin %} | <a href="{{ url_for('admin') }}">Admin</a>{% endif %}</p>
+{% endif %}
+
+<form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data">
+  <div class="field has-addons">
+    <div class="control"><input class="input" type="file" name="file"></div>
+    <div class="control"><button class="button is-link" type="submit">Upload</button></div>
+  </div>
+</form>
+
+<p><a href="{{ url_for('create_paste') }}">New Paste</a></p>
+
+<table class="table is-fullwidth">
+<tr><th>Name</th><th>Actions</th></tr>
+{% for f in files %}
+<tr>
+  <td><a href="{{ url_for('uploaded_file', name=f.stored_name) }}">{{ f.filename }}</a></td>
+  <td>
+    <form action="{{ url_for('rename_file', file_id=f.id) }}" method="post" style="display:inline">
+      <input name="name" class="input" placeholder="Rename" style="width:120px">
+    </form>
+    <form action="{{ url_for('set_expiration', file_id=f.id) }}" method="post" style="display:inline">
+      <input name="expire" class="input" type="date" style="width:120px">
+    </form>
+    <a class="button is-small is-danger" href="{{ url_for('delete_file', file_id=f.id) }}">Delete</a>
+  </td>
+</tr>
+{% endfor %}
+</table>
+
+{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.3/css/bulma.min.css">
+  <title>Uploader</title>
+</head>
+<body>
+<section class="section">
+<div class="container">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="notification is-warning">
+        {% for m in messages %}{{ m }}<br>{% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+  {% block content %}{% endblock %}
+</div>
+</section>
+</body>
+</html>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,15 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title">Login</h2>
+<form method="post">
+  <div class="field">
+    <label class="label">Username</label>
+    <div class="control"><input class="input" type="text" name="username"></div>
+  </div>
+  <div class="field">
+    <label class="label">Password</label>
+    <div class="control"><input class="input" type="password" name="password"></div>
+  </div>
+  <button class="button is-link" type="submit">Login</button>
+</form>
+{% endblock %}

--- a/app/templates/paste.html
+++ b/app/templates/paste.html
@@ -1,0 +1,12 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title">New Paste</h2>
+<form method="post">
+  <div class="field">
+    <div class="control">
+      <textarea class="textarea" name="content" rows="10" style="font-family:monospace"></textarea>
+    </div>
+  </div>
+  <button class="button is-link" type="submit">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,15 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title">Register</h2>
+<form method="post">
+  <div class="field">
+    <label class="label">Username</label>
+    <div class="control"><input class="input" type="text" name="username"></div>
+  </div>
+  <div class="field">
+    <label class="label">Password</label>
+    <div class="control"><input class="input" type="password" name="password"></div>
+  </div>
+  <button class="button is-link" type="submit">Register</button>
+</form>
+{% endblock %}

--- a/app/templates/view_paste.html
+++ b/app/templates/view_paste.html
@@ -1,0 +1,15 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2 class="title">Paste {{ paste.id }}</h2>
+<form method="post">
+  <div class="field">
+    <div class="control">
+      <textarea class="textarea" name="content" rows="10" style="font-family:monospace">{{ paste.content }}</textarea>
+    </div>
+  </div>
+  <button class="button is-link" type="submit">Update</button>
+</form>
+{% if current_user.is_authenticated %}
+<p><a class="button is-danger" href="{{ url_for('delete_paste', paste_id=paste.id) }}">Delete</a></p>
+{% endif %}
+{% endblock %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,8 @@
+import os
+from flask import session
+from . import app
+
+@app.before_request
+def ensure_session():
+    if 'sid' not in session:
+        session['sid'] = os.urandom(8).hex()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+Flask-Login
+Flask-SQLAlchemy
+Flask-Limiter
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,49 @@
+import os
+import io
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import app, db
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    client = app.test_client()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    yield client
+
+
+def register(client, username, password):
+    return client.post('/register', data={'username': username, 'password': password}, follow_redirects=True)
+
+
+def login(client, username, password):
+    return client.post('/login', data={'username': username, 'password': password}, follow_redirects=True)
+
+
+def test_register_login(client):
+    rv = register(client, 'user', 'pass')
+    assert b'Registered' in rv.data
+    rv = login(client, 'user', 'pass')
+    assert b'Welcome' in rv.data
+
+
+def test_guest_upload_limit(client):
+    data = {
+        'file': (io.BytesIO(b'a' * (11 * 1024 * 1024)), 'big.txt')
+    }
+    rv = client.post('/upload', data=data, content_type='multipart/form-data', follow_redirects=True)
+    assert b'File too large' in rv.data
+
+
+def test_user_upload_limit(client):
+    register(client, 'user2', 'pass')
+    login(client, 'user2', 'pass')
+    data = {
+        'file': (io.BytesIO(b'a' * (41 * 1024 * 1024)), 'big.txt')
+    }
+    rv = client.post('/upload', data=data, content_type='multipart/form-data', follow_redirects=True)
+    assert b'File too large' in rv.data


### PR DESCRIPTION
## Summary
- build Flask app for uploading files and text pastes
- handle guest uploads, registered users and admins
- add simple templates and admin dashboard
- implement session ID handling and rate limits
- add unit tests for user flow and upload limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434893a1fc832bb9e75fbd56e72583

## Summary by Sourcery

Implement a minimal Flask-based file and paste sharing service with guest and authenticated user quotas, rate limiting, session support, an admin dashboard, and accompanying unit tests

New Features:
- Implement file upload endpoints with guest (10MB) and authenticated user (40MB) quotas
- Add paste creation, viewing, editing, and deletion routes for text sharing
- Provide an admin dashboard to inspect users and uploaded files
- Enforce rate limits on registration, login, upload, and paste endpoints
- Maintain per-session handling for guest uploads and pastes

Enhancements:
- Introduce Bulma-based HTML templates and a shared layout
- Allow file renaming and expiration date settings
- Initialize and track session IDs via a before_request hook

Build:
- Add requirements.txt with project dependencies

Documentation:
- Update README with project features, development setup, and testing instructions

Tests:
- Add unit tests for user registration/login and upload size limits